### PR TITLE
[부서 수정] 설립일자만 변경 시 중복 부서명 오류 해결

### DIFF
--- a/src/main/java/com/fource/hrbank/service/department/DepartmentServiceImpl.java
+++ b/src/main/java/com/fource/hrbank/service/department/DepartmentServiceImpl.java
@@ -96,9 +96,14 @@ public class DepartmentServiceImpl implements DepartmentService {
         Department department = departmentRepository.findById(departmentId)
                 .orElseThrow(DepartmentNotFoundException::new);
 
-        if (departmentRepository.existsByName(request.getName())) throw new DuplicateDepartmentException();
+        if (request.getName() != null && !request.getName().equals(department.getName())) {
+            if (departmentRepository.existsByName(request.getName())) {
+                throw new DuplicateDepartmentException();
+            }
+        }
 
         department.update(request);
+
         return departmentMapper.toDto(department, null);
     }
 


### PR DESCRIPTION
## 📌 작업 개요
- 설립일자만 수정할 경우에도 request.name != null && !request.name.equals(name) 조건이 true가 되지 않아서 기존 이름으로 중복 검사를 통과하지 못하는 문제 발생
- name 변경 없이도 중복 검사 로직이 동작하던 기존 버그 해결

## 🔧 주요 작업 내용
- [x] `DepartmentService.update()`에서 이름이 변경된 경우에만 중복 검사하도록 분기 처리
- [x] `Department.update()` 메서드 활용하여 필드 값 변경 로직 위임

## ✅ 확인 사항
- [x] 로컬 개발 환경에서 정상 동작 확인 

## 🧪 테스트 방법
- 로컬 개발 환경에서 수정 테스트

## 📎 기타 참고 사항
-

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
