### PR TITLE
[직원 수 추이 조회] 직원 수 추이 조회 기능 구현

### DIFF
--- a/src/main/java/com/fource/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/fource/hrbank/controller/EmployeeController.java
@@ -2,11 +2,11 @@ package com.fource.hrbank.controller;
 
 import com.fource.hrbank.controller.api.EmployeeApi;
 import com.fource.hrbank.domain.EmployeeStatus;
-import com.fource.hrbank.dto.dashboard.EmployeeTrendDto;
 import com.fource.hrbank.dto.employee.CursorPageResponseEmployeeDto;
 import com.fource.hrbank.dto.employee.EmployeeCreateRequest;
 import com.fource.hrbank.dto.employee.EmployeeDistributionDto;
 import com.fource.hrbank.dto.employee.EmployeeDto;
+import com.fource.hrbank.dto.employee.EmployeeTrendDto;
 import com.fource.hrbank.dto.employee.EmployeeUpdateRequest;
 import com.fource.hrbank.service.dashboard.DashboardService;
 import com.fource.hrbank.service.employee.EmployeeService;
@@ -114,13 +114,23 @@ public class EmployeeController implements EmployeeApi {
         return ResponseEntity.ok(distribution);
     }
 
-//    @GetMapping("/count")
-//    public ResponseEntity<EmployeeTrendDto> getEmployeeCount(
-//        @RequestParam(required = false) EmployeeStatus status,
-//        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
-//        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate
-//    ) {
-//        EmployeeTrendDto response = dashboardService.getEmployeeCount(status, fromDate, toDate);
-//        return ResponseEntity.ok(response);
-//    }
+    @GetMapping("/count")
+    public ResponseEntity<EmployeeTrendDto> getEmployeeCount(
+        @RequestParam(required = false) EmployeeStatus status,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate
+    ) {
+        EmployeeTrendDto response = dashboardService.getEmployeeCount(status, fromDate, toDate);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/stats/trend")
+    public ResponseEntity<List<EmployeeTrendDto>> getEmployeeTrend(
+        @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+        @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+        @RequestParam("unit") String unit // 예: "month", "week"
+    ) {
+        List<EmployeeTrendDto> trend = dashboardService.getEmployeeTrend(from, to, unit);
+        return ResponseEntity.ok(trend);
+    }
 }

--- a/src/main/java/com/fource/hrbank/dto/dashboard/EmployeeDistributionDto.java
+++ b/src/main/java/com/fource/hrbank/dto/dashboard/EmployeeDistributionDto.java
@@ -1,7 +1,7 @@
-package com.fource.hrbank.dto.dashboard;
-
-public record EmployeeDistributionDto(
-    String groupKey,   // 부서명
-    int count,         // 해당 그룹 직원 수
-    double percentage  // 전체 대비 비율 (%)
-) {}
+//package com.fource.hrbank.dto.dashboard;
+//
+//public record EmployeeDistributionDto(
+//    String groupKey,   // 부서명
+//    int count,         // 해당 그룹 직원 수
+//    double percentage  // 전체 대비 비율 (%)
+//) {}

--- a/src/main/java/com/fource/hrbank/dto/dashboard/EmployeeTrendDto.java
+++ b/src/main/java/com/fource/hrbank/dto/dashboard/EmployeeTrendDto.java
@@ -1,13 +1,14 @@
-package com.fource.hrbank.dto.dashboard;
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class EmployeeTrendDto {
-    private String date;       // yyyy-MM 형태의 문자열 (예: "2025-06")
-    private long count;        // 해당 월의 총 직원 수
-    private long change;       // 전월 대비 변화량
-    private double changeRate; // 전월 대비 변화율 (예: -12.5)
-}
+//package com.fource.hrbank.dto.dashboard;
+//
+//import java.time.LocalDate;
+//import lombok.AllArgsConstructor;
+//import lombok.Getter;
+//
+//@Getter
+//@AllArgsConstructor
+//public class EmployeeTrendDto {
+//    private LocalDate date;       // yyyy-MM 형태의 문자열 (예: "2025-06")
+//    private long count;        // 해당 월의 총 직원 수
+//    private long change;       // 전월 대비 변화량
+//    private double changeRate; // 전월 대비 변화율 (예: -12.5)
+//}

--- a/src/main/java/com/fource/hrbank/repository/employee/EmployeeRepository.java
+++ b/src/main/java/com/fource/hrbank/repository/employee/EmployeeRepository.java
@@ -50,6 +50,13 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>,
     WHERE (:status IS NULL OR e.status = :status)
 """)
     long countAllByStatus(@Param("status") EmployeeStatus status);
+
+    @Query("""
+  SELECT COUNT(e)
+  FROM Employee e
+  WHERE e.status = 'ACTIVE' AND e.hireDate <= :date
+""")
+    long countByDateRange(@Param("date") LocalDate date);
 }
 
 

--- a/src/main/java/com/fource/hrbank/service/dashboard/DashboardService.java
+++ b/src/main/java/com/fource/hrbank/service/dashboard/DashboardService.java
@@ -1,8 +1,8 @@
 package com.fource.hrbank.service.dashboard;
 
 import com.fource.hrbank.domain.EmployeeStatus;
-import com.fource.hrbank.dto.dashboard.EmployeeDistributionDto;
-import com.fource.hrbank.dto.dashboard.EmployeeTrendDto;
+import com.fource.hrbank.dto.employee.EmployeeDistributionDto;
+import com.fource.hrbank.dto.employee.EmployeeTrendDto;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -10,4 +10,9 @@ public interface DashboardService {
     EmployeeTrendDto getEmployeeCount(EmployeeStatus status, LocalDate from, LocalDate to);
 
     List<EmployeeDistributionDto> getEmployeeDistribution(String groupBy, EmployeeStatus status);
+
+    List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, String unit);
+
+    long getEmployeeCountByDate(LocalDate date);
+
 }

--- a/src/main/java/com/fource/hrbank/service/dashboard/DashboardServiceImpl.java
+++ b/src/main/java/com/fource/hrbank/service/dashboard/DashboardServiceImpl.java
@@ -2,10 +2,11 @@ package com.fource.hrbank.service.dashboard;
 
 import com.fource.hrbank.annotation.Logging;
 import com.fource.hrbank.domain.EmployeeStatus;
-import com.fource.hrbank.dto.dashboard.EmployeeDistributionDto;
-import com.fource.hrbank.dto.dashboard.EmployeeTrendDto;
+import com.fource.hrbank.dto.employee.EmployeeDistributionDto;
+import com.fource.hrbank.dto.employee.EmployeeTrendDto;
 import com.fource.hrbank.repository.employee.EmployeeRepository;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,42 +17,88 @@ import org.springframework.stereotype.Service;
 @Logging
 public class DashboardServiceImpl implements DashboardService {
 
-  private final EmployeeRepository employeeRepository;
+    private final EmployeeRepository employeeRepository;
 
-  @Override
-  public EmployeeTrendDto getEmployeeCount(EmployeeStatus status, LocalDate from, LocalDate to) {
-    // 현재 기간의 직원 수
-    long count = employeeRepository.count();
+    // 직원 수 조회
+    @Override
+    public EmployeeTrendDto getEmployeeCount(EmployeeStatus status, LocalDate from, LocalDate to) {
+      // 현재 기간의 직원 수
+      long count = employeeRepository.count();
 
-    // 전월 대비 값 (임시로 0 지정)
-    long change = 0;
-    double changeRate = 0.0;
+      // 전월 대비 값 (임시로 0 지정)
+      long change = 0;
+      double changeRate = 0.0;
 
-    // from이 null이 아니라면 yyyy-MM 형식으로 표시
-    String dateString = (from != null) ? from.toString().substring(0, 7) : "unknown";
+      // from이 null이 아니라면 yyyy-MM 형식으로 표시
+      LocalDate date = (from != null) ? from.withDayOfMonth(1) : LocalDate.of(1970, 1, 1);
 
-    return new EmployeeTrendDto(dateString, count, change, changeRate);
-  }
+      return new EmployeeTrendDto(date, count, change, changeRate);
+    }
+    @Override
+    public long getEmployeeCountByDate(LocalDate date) {
+      return employeeRepository.countByDateRange(date);
+    }
 
-  @Override
-  public List<EmployeeDistributionDto> getEmployeeDistribution(String groupBy, EmployeeStatus status) {
-    long total = employeeRepository.countAllByStatus(status);  // 이미 있는 쿼리 메서드 사용
+    // 직원 수 분포 통계
+    @Override
+    public List<EmployeeDistributionDto> getEmployeeDistribution(String groupBy, EmployeeStatus status) {
+      long total = employeeRepository.countAllByStatus(status);  // 이미 있는 쿼리 메서드 사용
 
-    return switch (groupBy) {
-      case "department" -> toDistributionDto(employeeRepository.countByDepartmentGroup(status), total);
-      case "position" -> toDistributionDto(employeeRepository.countByPositionGroup(status), total);
-      default -> throw new IllegalArgumentException("지원하지 않는 groupBy 값: " + groupBy);
-    };
-  }
+      return switch (groupBy) {
+        case "department" -> toDistributionDto(employeeRepository.countByDepartmentGroup(status), total);
+        case "position" -> toDistributionDto(employeeRepository.countByPositionGroup(status), total);
+        default -> throw new IllegalArgumentException("지원하지 않는 groupBy 값: " + groupBy);
+      };
+    }
 
-  private List<EmployeeDistributionDto> toDistributionDto(List<Object[]> raw, long totalCount) {
-    return raw.stream()
-        .map(row -> {
-          String groupValue = (String) row[0];
-          long count = (long) row[1];
-          double ratio = totalCount > 0 ? (count * 100.0) / totalCount : 0.0;
-          return new EmployeeDistributionDto(groupValue, Math.toIntExact(count), ratio);
-        })
-        .toList();
-  }
+    private List<EmployeeDistributionDto> toDistributionDto(List<Object[]> raw, long totalCount) {
+      return raw.stream()
+          .map(row -> {
+            String groupValue = (String) row[0];
+            long count = (long) row[1];
+            double ratio = totalCount > 0 ? (count * 100.0) / totalCount : 0.0;
+            return new EmployeeDistributionDto(groupValue, count, ratio);
+          })
+          .toList();
+    }
+    // 직원 수 추이
+      @Override
+      public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, String unit) {
+        if (from == null || to == null) {
+          to = LocalDate.now();
+          from = to.minusMonths(11).withDayOfMonth(1); // 최근 12개월 기준
+        }
+
+        // 월 단위 분기: LocalDate 리스트 생성
+        List<LocalDate> periods = getMonthlyPeriods(from, to);
+
+        List<EmployeeTrendDto> results = new ArrayList<>();
+        Long previousCount = null;
+
+        for (LocalDate date : periods) {
+          LocalDate start = date.withDayOfMonth(1);
+          LocalDate end = start.plusMonths(1).minusDays(1);
+
+          long count = employeeRepository.countByDateRange(end); // 시점 기준 직원 수
+
+          long change = (previousCount != null) ? (count - previousCount) : 0;
+          double percentage = (previousCount != null && previousCount > 0)
+              ? (change * 100.0 / previousCount)
+              : 0.0;
+
+          results.add(new EmployeeTrendDto(start, count, change, percentage));
+          previousCount = count;
+        }
+
+        return results;
+    }
+        private List<LocalDate> getMonthlyPeriods(LocalDate from, LocalDate to) {
+          List<LocalDate> months = new ArrayList<>();
+          LocalDate current = from.withDayOfMonth(1);
+          while (!current.isAfter(to)) {
+            months.add(current);
+            current = current.plusMonths(1);
+          }
+          return months;
+        }
 }

--- a/src/test/java/com/fource/hrbank/service/ChangeLogServiceTest.java
+++ b/src/test/java/com/fource/hrbank/service/ChangeLogServiceTest.java
@@ -9,12 +9,9 @@
 //import com.fource.hrbank.domain.Employee;
 //import com.fource.hrbank.domain.EmployeeStatus;
 //import com.fource.hrbank.dto.changelog.ChangeLogDto;
-//<<<<<<< HEAD
 //import com.fource.hrbank.dto.employee.EmployeeUpdateRequest;
 //import com.fource.hrbank.repository.change.ChangeDetailRepository;
-//=======
 //import com.fource.hrbank.dto.changelog.CursorPageResponseChangeLogDto;
-//>>>>>>> 29d012f1a17e059df9b7a0a02a440901264262e2
 //import com.fource.hrbank.repository.change.ChangeLogRepository;
 //import com.fource.hrbank.repository.DepartmentRepository;
 //import com.fource.hrbank.repository.employee.EmployeeRepository;
@@ -23,12 +20,9 @@
 //import com.fource.hrbank.service.storage.FileStorage;
 //import java.time.Instant;
 //import java.time.LocalDate;
-//<<<<<<< HEAD
 //import java.util.List;
 //import java.util.Optional;
-//=======
 //import java.util.Comparator;
-//>>>>>>> 29d012f1a17e059df9b7a0a02a440901264262e2
 //import org.junit.jupiter.api.BeforeEach;
 //import org.junit.jupiter.api.DisplayName;
 //import org.junit.jupiter.api.Test;
@@ -196,6 +190,7 @@
 //
 //        ChangeLog changeLog1 = new ChangeLog(
 //            employee,
+//            employee.getEmployeeNumber(),
 //            Instant.now().minusSeconds(60),
 //            "100.10.1.1",
 //            ChangeType.UPDATED,
@@ -204,6 +199,7 @@
 //        );
 //        ChangeLog changeLog2 = new ChangeLog(
 //            employee,
+//            employee.getEmployeeNumber(),
 //            Instant.now().minusSeconds(30),
 //            "100.10.1.2",
 //            ChangeType.UPDATED,
@@ -212,6 +208,7 @@
 //        );
 //        ChangeLog changeLog3 = new ChangeLog(
 //            employee,
+//            employee.getEmployeeNumber(),
 //            Instant.now(),
 //            "100.10.1.3",
 //            ChangeType.UPDATED,

--- a/src/test/java/com/fource/hrbank/service/DashboardServiceTest.java
+++ b/src/test/java/com/fource/hrbank/service/DashboardServiceTest.java
@@ -1,7 +1,7 @@
 package com.fource.hrbank.service;
 
 import com.fource.hrbank.domain.EmployeeStatus;
-import com.fource.hrbank.dto.dashboard.EmployeeTrendDto;
+import com.fource.hrbank.dto.employee.EmployeeTrendDto;
 import com.fource.hrbank.service.dashboard.DashboardService;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
@@ -28,7 +28,7 @@ class DashboardServiceTest {
         EmployeeTrendDto result = dashboardService.getEmployeeCount(null, from, to);
 
         // then
-        assertThat(result.getCount()).isGreaterThanOrEqualTo(0);
+        assertThat(result.count()).isGreaterThanOrEqualTo(0);
     }
 
     @Test
@@ -37,6 +37,6 @@ class DashboardServiceTest {
         LocalDate to = LocalDate.of(2024,12,31);
         EmployeeTrendDto result = dashboardService.getEmployeeCount(EmployeeStatus.ACTIVE, from, to);
 
-        assertThat(result.getCount()).isGreaterThanOrEqualTo(0);
+        assertThat(result.count()).isGreaterThanOrEqualTo(0);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 직원 수 추이 통계 API (`/api/employees/stats/trend`)
- 특정 날짜 기준 직원 수 조회 API (`/api/employees/stats/count`)
- DashboardService 관련 메서드 추가 및 구현
- 테스트 코드 보완 및 주석 정리

## 🔧 주요 작업 내용
- [x] EmployeeController 경로 추가 및 수정
- [x] EmployeeRepository에 countByDateRange 쿼리 추가
- [x] DashboardService 인터페이스 및 구현체 메서드 추가
- [x] EmployeeTrendDto 구조 활용
- [x] 단위 테스트 보완

## ✅ 확인 사항

## 🧪 테스트 방법
- IntelliJ에서 JUnit테스트 완료

<img width="1417" alt="스크린샷 2025-06-11 오전 5 51 06" src="https://github.com/user-attachments/assets/c926c2ee-34c4-484c-aead-09220501ee6b" />


<img width="1417" alt="스크린샷 2025-06-11 오전 5 51 43" src="https://github.com/user-attachments/assets/eb5b7cc6-e82c-4891-8a15-a0334cab1aeb" />


<img width="1042" alt="스크린샷 2025-06-11 오전 6 21 36" src="https://github.com/user-attachments/assets/9397bf81-0048-4eed-b1fe-ca0b616e9759" />


## 📎 기타 참고 사항
- 일단 dto/dashboard에 있는 employeeDistributionDto와 employeeTrendDto를 dto/employee 쪽으로 경로 수정하고 관련 다른 곳들도 경로 수정하긴 했는데 단위 테스트는 통과하는데 다시 http://localhost:8080/ 들어갔을 때 백지가 돼서 수정이 필요할 것 같습니다 🥹
-  employee_number가 employee_id와 같은 정보를 표현하는데, 형식만 다르고 중복 저장되는 컬럼이라 문제가 생기는 건지 잘 모르겠습니다!

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
