### PR TITLE
[테스트 버그 수정] setUp() 실행조건 수정

### DIFF
--- a/src/test/java/com/fource/hrbank/service/DashboardServiceTest.java
+++ b/src/test/java/com/fource/hrbank/service/DashboardServiceTest.java
@@ -6,6 +6,7 @@ import com.fource.hrbank.service.dashboard.DashboardService;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/com/fource/hrbank/service/DepartmentServiceTest.java
+++ b/src/test/java/com/fource/hrbank/service/DepartmentServiceTest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,23 +46,28 @@ public class DepartmentServiceTest {
     @Autowired
     private EntityManager entityManager;
 
+    @Value("${spring.profiles.active}")
+    private String profile;
+
     @BeforeEach
     void setUp() {
-        // 테이블 삭제
-        employeeRepository.deleteAll();
-        departmentRepository.deleteAll();
+        if (!profile.equals("local")) {
+            // 테이블 삭제
+            employeeRepository.deleteAll();
+            departmentRepository.deleteAll();
 
-        // 시퀀스를 "테이블의 MAX(id) + 1"로 세팅
-        jdbcTemplate.execute("""
+            // 시퀀스를 "테이블의 MAX(id) + 1"로 세팅
+            jdbcTemplate.execute("""
                 SELECT setval('tbl_department_id_seq', 
                               COALESCE((SELECT MAX(id) FROM tbl_department), 0) + 1,
                               false)
             """);
-        jdbcTemplate.execute("""
+            jdbcTemplate.execute("""
                 SELECT setval('tbl_employees_id_seq', 
                               COALESCE((SELECT MAX(id) FROM tbl_employees), 0) + 1,
                               false)
             """);
+        }
     }
 
     @Test

--- a/src/test/java/com/fource/hrbank/service/EmployeeServiceTest.java
+++ b/src/test/java/com/fource/hrbank/service/EmployeeServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -50,11 +51,16 @@ class EmployeeServiceTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @Value("${spring.profiles.active}")
+    private String profile;
+
     @BeforeEach
     void setUp() {
-        //시퀀스 초기화
-        jdbcTemplate.execute(
-            "TRUNCATE TABLE tbl_change_detail, tbl_change_log, tbl_employees RESTART IDENTITY CASCADE");
+        if (!profile.equals("local")) {
+            //시퀀스 초기화
+            jdbcTemplate.execute(
+                    "TRUNCATE TABLE tbl_change_detail, tbl_change_log, tbl_employees RESTART IDENTITY CASCADE");
+        }
     }
 
     @Test

--- a/src/test/java/com/fource/hrbank/service/LocalFileStorageTest.java
+++ b/src/test/java/com/fource/hrbank/service/LocalFileStorageTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -43,13 +44,18 @@ public class LocalFileStorageTest {
     @TempDir
     Path tempDir;
 
+    @Value("${spring.profiles.active}")
+    private String profile;
+
     @BeforeEach
     void setUp() {
         fileStorage = new LocalFileStorage(tempDir.toString());
         fileStorage.init();
 
         // 테이블 ID 시퀀스 초기화
-        jdbcTemplate.execute("TRUNCATE TABLE tbl_file_metadata RESTART IDENTITY CASCADE");
+        if (!profile.equals("local")) {
+            jdbcTemplate.execute("TRUNCATE TABLE tbl_file_metadata RESTART IDENTITY CASCADE");
+        }
     }
 
     @Test
@@ -139,7 +145,7 @@ public class LocalFileStorageTest {
         // when
         assertThatThrownBy(() -> fileStorage.get(id))
             .isInstanceOf(FileNotFoundException.class)
-            .hasMessage(ResponseDetails.FILE_NOT_FOUND_ERROR_MESSAGE);
+            .hasMessage(ResponseMessage.FILE_NOT_FOUND_ERROR_MESSAGE);
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업 개요
- setUp() 메서드의 쿼리가 H2데이터베이스 문법과 맞지 않아 에러 발생 -> 해결


## 🔧 주요 작업 내용
- [x] profile 값에 따라 local이 아닐때만  setUp() 메서드 로직을 실행하게끔 수정

## ✅ 확인 사항
- [x] 단위 테스트 통과

## 🧪 테스트 방법
- 단위 테스트 통과

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
