### PR TITLE
[버그 수정] 가장 최근 백업이력 없을시 예외 아닌 null 값으로 반환

### DIFF
--- a/src/main/java/com/fource/hrbank/service/backup/BackupServiceImpl.java
+++ b/src/main/java/com/fource/hrbank/service/backup/BackupServiceImpl.java
@@ -101,10 +101,10 @@ public class BackupServiceImpl implements BackupService {
     @Override
     @Transactional(readOnly = true)
     public BackupDto findLatestByStatus(BackupStatus status) {
-        BackupLog backupLog = backupLogRepository.findLatestByStatus(status)
-            .orElseThrow(BackupLogNotFoundException::new);
 
-        return backupLogMapper.toDto(backupLog);
+        return backupLogRepository.findLatestByStatus(status)
+                .map(backupLogMapper::toDto)
+                .orElse(null);
     }
 
     /**

--- a/src/test/java/com/fource/hrbank/service/BackupServiceTest.java
+++ b/src/test/java/com/fource/hrbank/service/BackupServiceTest.java
@@ -127,7 +127,7 @@ public class BackupServiceTest {
     void findLatestByStatus_정상조회_최근백업반환() {
         // given
         BackupLog oldLog = new BackupLog("127.0.0.1", Instant.now().minusSeconds(3600), Instant.now().minusSeconds(3590), BackupStatus.COMPLETED, null);
-        BackupLog newLog = new BackupLog("127.0.0.1", Instant.now().minusSeconds(1800), Instant.now().minusSeconds(1790), BackupStatus.COMPLETED, null);
+        BackupLog newLog = new BackupLog("127.0.0.1", Instant.now(), Instant.now(), BackupStatus.COMPLETED, null);
         List<BackupLog> logs = List.of(oldLog, newLog);
         backupLogRepository.saveAll(logs);
 
@@ -142,7 +142,7 @@ public class BackupServiceTest {
     }
 
     @Test
-    void findLatestByStatus_조회결과없음_예외발생() {
+    void findLatestByStatus_조회결과없음_null값반환() {
         // given
         BackupLog oldLog = new BackupLog("127.0.0.1", Instant.now().minusSeconds(3600), Instant.now().minusSeconds(3590), BackupStatus.COMPLETED, null);
         BackupLog newLog = new BackupLog("127.0.0.1", Instant.now().minusSeconds(1800), Instant.now().minusSeconds(1790), BackupStatus.COMPLETED, null);
@@ -150,9 +150,7 @@ public class BackupServiceTest {
         backupLogRepository.saveAll(logs);
 
         // when & then
-        assertThatThrownBy(() -> backupService.findLatestByStatus(BackupStatus.SKIPPED))
-                .isInstanceOf(BackupLogNotFoundException.class)
-                .hasMessage(ResponseMessage.BACKUPLOG_NOT_FOUND_ERROR_MESSAGE);
+        assertThat(backupService.findLatestByStatus(BackupStatus.SKIPPED)).isNull();
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업 개요
- 가장 최근 백업이력 조회시 없으면 예외처리하였는데, null 값 반환으로 수정
- 

## 🔧 주요 작업 내용
- [x] BackupServiceImpl의 findLatestByStatus() 메서드 리턴값 수정

## ✅ 확인 사항
- [x] 로컬 서버에서 테스트 완료

## 🧪 테스트 방법
- Postman, Swagger UI 등을 통해 직접 확인한 테스트 내용
- 

## 📎 기타 참고 사항
- 추가 논의가 필요한 사항
- 관련 이슈, API 문서 링크 등

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.
