### PR TITLE
[대시보드 수정] 단위별 직원 통계 구현 및 서비스 리팩토링

### DIFF
--- a/src/main/java/com/fource/hrbank/controller/ChangeLogController.java
+++ b/src/main/java/com/fource/hrbank/controller/ChangeLogController.java
@@ -8,6 +8,7 @@ import com.fource.hrbank.service.changelog.ChangeLogService;
 import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,10 +51,19 @@ public class ChangeLogController{
 
     @GetMapping("/count")
     public ResponseEntity<Long> count(
-        @RequestParam(required = false) Instant atFrom,
-        @RequestParam(required = false) Instant atTo
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant atFrom,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant atTo
     ) {
-        long count = changeLogService.countByCreatedAtBetween(atFrom, atTo);
-        return ResponseEntity.ok(count);
+
+        // null일 경우 기본값 지정 (최근 7일)
+        Instant now = Instant.now();
+        if (atTo == null) {
+            atTo = now;
+        }
+        if (atFrom == null) {
+            atFrom = atTo.minusSeconds(7 * 24 * 60 * 60); // 7일 전
+        }
     }
 }

--- a/src/main/java/com/fource/hrbank/controller/ChangeLogController.java
+++ b/src/main/java/com/fource/hrbank/controller/ChangeLogController.java
@@ -65,5 +65,8 @@ public class ChangeLogController{
         if (atFrom == null) {
             atFrom = atTo.minusSeconds(7 * 24 * 60 * 60); // 7일 전
         }
+
+        long count = changeLogService.countByCreatedAtBetween(atFrom, atTo);
+        return ResponseEntity.ok(count);
     }
 }

--- a/src/main/java/com/fource/hrbank/controller/EmployeeController.java
+++ b/src/main/java/com/fource/hrbank/controller/EmployeeController.java
@@ -9,7 +9,6 @@ import com.fource.hrbank.dto.employee.EmployeeDto;
 import com.fource.hrbank.dto.employee.EmployeeUpdateRequest;
 import com.fource.hrbank.service.dashboard.DashboardService;
 import com.fource.hrbank.service.employee.EmployeeService;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -125,17 +124,15 @@ public class EmployeeController implements EmployeeApi {
     }
 
     @GetMapping("/count")
-    public ResponseEntity<Long> countChangeLogs(
+    public ResponseEntity<Long> countEmployees(
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate fromDate,
         @RequestParam(required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate toDate
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDate toDate,
+        @RequestParam(required = false)
+        EmployeeStatus status
     ) {
-        long count = dashboardService.getEmployeeTrend(
-            fromDate,
-            toDate,
-            "day"
-        ).size();
+        long count = employeeService.getEmployeeCount(status, fromDate, toDate);
         return ResponseEntity.ok(count);
     }
 }

--- a/src/main/java/com/fource/hrbank/repository/employee/EmployeeCustomRepository.java
+++ b/src/main/java/com/fource/hrbank/repository/employee/EmployeeCustomRepository.java
@@ -2,6 +2,7 @@ package com.fource.hrbank.repository.employee;
 
 import com.fource.hrbank.domain.EmployeeStatus;
 import com.fource.hrbank.dto.employee.EmployeeDistributionDto;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface EmployeeCustomRepository {
@@ -9,4 +10,7 @@ public interface EmployeeCustomRepository {
     long countByStatus(EmployeeStatus status);
 
     List<EmployeeDistributionDto> getDistributionByGroup(String groupBy, EmployeeStatus status);
+
+    long countByFilters(EmployeeStatus status, LocalDate from, LocalDate to);
+
 }

--- a/src/main/java/com/fource/hrbank/repository/employee/EmployeeCustomRepositoryImpl.java
+++ b/src/main/java/com/fource/hrbank/repository/employee/EmployeeCustomRepositoryImpl.java
@@ -7,6 +7,10 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +23,32 @@ public class EmployeeCustomRepositoryImpl implements EmployeeCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     private final QEmployee employee = QEmployee.employee;
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    @Override
+    public long countByFilters(EmployeeStatus status, LocalDate from, LocalDate to) {
+        StringBuilder jpql = new StringBuilder("SELECT COUNT(e) FROM Employee e WHERE 1=1");
+
+        if (status != null) {
+            jpql.append(" AND e.status = :status");
+        }
+        if (from != null) {
+            jpql.append(" AND e.hireDate >= :from");
+        }
+        if (to != null) {
+            jpql.append(" AND e.hireDate <= :to");
+        }
+
+        TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
+
+        if (status != null) query.setParameter("status", status);
+        if (from != null) query.setParameter("from", from);
+        if (to != null) query.setParameter("to", to);
+
+        return query.getSingleResult();
+    }
 
     // 상태별 전체 직원 수 조회
     public long countByStatus(EmployeeStatus status) {

--- a/src/main/java/com/fource/hrbank/service/dashboard/DashboardServiceImpl.java
+++ b/src/main/java/com/fource/hrbank/service/dashboard/DashboardServiceImpl.java
@@ -5,12 +5,12 @@ import com.fource.hrbank.domain.EmployeeStatus;
 import com.fource.hrbank.dto.employee.EmployeeDistributionDto;
 import com.fource.hrbank.dto.employee.EmployeeTrendDto;
 import com.fource.hrbank.repository.employee.EmployeeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 
 @Service
 @RequiredArgsConstructor
@@ -19,30 +19,24 @@ public class DashboardServiceImpl implements DashboardService {
 
     private final EmployeeRepository employeeRepository;
 
-    // 직원 수 조회
     @Override
     public EmployeeTrendDto getEmployeeCount(EmployeeStatus status, LocalDate from, LocalDate to) {
-      // 현재 기간의 직원 수
       long count = employeeRepository.count();
-
-      // 전월 대비 값 (임시로 0 지정)
       long change = 0;
       double changeRate = 0.0;
 
-      // from이 null이 아니라면 yyyy-MM 형식으로 표시
-      LocalDate date = (from != null) ? from.withDayOfMonth(1) : LocalDate.of(1970, 1, 1);
-
+      LocalDate date = (from != null) ? from : LocalDate.of(1970, 1, 1);
       return new EmployeeTrendDto(date, count, change, changeRate);
     }
+
     @Override
     public long getEmployeeCountByDate(LocalDate date) {
       return employeeRepository.countByDateRange(date);
     }
 
-    // 직원 수 분포 통계
     @Override
     public List<EmployeeDistributionDto> getEmployeeDistribution(String groupBy, EmployeeStatus status) {
-      long total = employeeRepository.countAllByStatus(status);  // 이미 있는 쿼리 메서드 사용
+      long total = employeeRepository.countAllByStatus(status);
 
       return switch (groupBy) {
         case "department" -> toDistributionDto(employeeRepository.countByDepartmentGroup(status), total);
@@ -61,44 +55,95 @@ public class DashboardServiceImpl implements DashboardService {
           })
           .toList();
     }
-    // 직원 수 추이
-      @Override
-      public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, String unit) {
-        if (from == null || to == null) {
-          to = LocalDate.now();
-          from = to.minusMonths(11).withDayOfMonth(1); // 최근 12개월 기준
-        }
 
-        // 월 단위 분기: LocalDate 리스트 생성
-        List<LocalDate> periods = getMonthlyPeriods(from, to);
+    @Override
+    public List<EmployeeTrendDto> getEmployeeTrend(LocalDate from, LocalDate to, String unit) {
+      if (from == null || to == null) {
+        to = LocalDate.now();
+        from = to.minusMonths(11).withDayOfMonth(1);
+      }
 
-        List<EmployeeTrendDto> results = new ArrayList<>();
-        Long previousCount = null;
+      List<LocalDate> periods = switch (unit) {
+        case "day" -> getDailyPeriods(from, to);
+        case "week" -> getWeeklyPeriods(from, to);
+        case "quarter" -> getQuarterlyPeriods(from, to);
+        case "year" -> getYearlyPeriods(from, to);
+        default -> getMonthlyPeriods(from, to);
+      };
 
-        for (LocalDate date : periods) {
-          LocalDate start = date.withDayOfMonth(1);
-          LocalDate end = start.plusMonths(1).minusDays(1);
+      List<EmployeeTrendDto> results = new ArrayList<>();
+      Long previousCount = null;
 
-          long count = employeeRepository.countByDateRange(end); // 시점 기준 직원 수
+      for (LocalDate start : periods) {
+        LocalDate end = switch (unit) {
+          case "day" -> start;
+          case "week" -> start.plusDays(6);
+          case "quarter" -> start.plusMonths(3).minusDays(1);
+          case "year" -> start.plusYears(1).minusDays(1);
+          default -> start.plusMonths(1).minusDays(1);
+        };
 
-          long change = (previousCount != null) ? (count - previousCount) : 0;
-          double percentage = (previousCount != null && previousCount > 0)
-              ? (change * 100.0 / previousCount)
-              : 0.0;
+        long count = employeeRepository.countByDateRange(end);
+        long change = (previousCount != null) ? (count - previousCount) : 0;
+        double percentage = (previousCount != null && previousCount > 0)
+            ? (change * 100.0 / previousCount)
+            : 0.0;
 
-          results.add(new EmployeeTrendDto(start, count, change, percentage));
-          previousCount = count;
-        }
+        results.add(new EmployeeTrendDto(start, count, change, percentage));
+        previousCount = count;
+      }
 
-        return results;
+      return results;
     }
-        private List<LocalDate> getMonthlyPeriods(LocalDate from, LocalDate to) {
-          List<LocalDate> months = new ArrayList<>();
-          LocalDate current = from.withDayOfMonth(1);
-          while (!current.isAfter(to)) {
-            months.add(current);
-            current = current.plusMonths(1);
-          }
-          return months;
-        }
+
+    private List<LocalDate> getDailyPeriods(LocalDate from, LocalDate to) {
+      List<LocalDate> days = new ArrayList<>();
+      LocalDate current = from;
+      while (!current.isAfter(to)) {
+        days.add(current);
+        current = current.plusDays(1);
+      }
+      return days;
+    }
+
+    private List<LocalDate> getWeeklyPeriods(LocalDate from, LocalDate to) {
+      List<LocalDate> weeks = new ArrayList<>();
+      LocalDate current = from.with(DayOfWeek.MONDAY);
+      while (!current.isAfter(to)) {
+        weeks.add(current);
+        current = current.plusWeeks(1);
+      }
+      return weeks;
+    }
+
+    private List<LocalDate> getMonthlyPeriods(LocalDate from, LocalDate to) {
+      List<LocalDate> months = new ArrayList<>();
+      LocalDate current = from.withDayOfMonth(1);
+      while (!current.isAfter(to)) {
+        months.add(current);
+        current = current.plusMonths(1);
+      }
+      return months;
+    }
+
+    private List<LocalDate> getQuarterlyPeriods(LocalDate from, LocalDate to) {
+      List<LocalDate> quarters = new ArrayList<>();
+      int month = ((from.getMonthValue() - 1) / 3) * 3 + 1;
+      LocalDate current = LocalDate.of(from.getYear(), month, 1);
+      while (!current.isAfter(to)) {
+        quarters.add(current);
+        current = current.plusMonths(3);
+      }
+      return quarters;
+    }
+
+    private List<LocalDate> getYearlyPeriods(LocalDate from, LocalDate to) {
+      List<LocalDate> years = new ArrayList<>();
+      LocalDate current = from.withDayOfYear(1);
+      while (!current.isAfter(to)) {
+        years.add(current);
+        current = current.plusYears(1);
+      }
+      return years;
+    }
 }

--- a/src/main/java/com/fource/hrbank/service/employee/EmployeeService.java
+++ b/src/main/java/com/fource/hrbank/service/employee/EmployeeService.java
@@ -23,7 +23,7 @@ public interface EmployeeService {
     EmployeeDto update(Long employeeId, EmployeeUpdateRequest request,
         Optional<MultipartFile> profileImage);
 
-//    long getEmployeeCount(EmployeeStatus status, LocalDate fromDate, LocalDate toDate);
+    long getEmployeeCount(EmployeeStatus status, LocalDate fromDate, LocalDate toDate);
 
     void deleteById(Long id);
 }

--- a/src/main/java/com/fource/hrbank/service/employee/EmployeeServiceImpl.java
+++ b/src/main/java/com/fource/hrbank/service/employee/EmployeeServiceImpl.java
@@ -339,4 +339,9 @@ public class EmployeeServiceImpl implements EmployeeService {
             Instant.now()
         );
     }
+
+    @Override
+    public long getEmployeeCount(EmployeeStatus status, LocalDate fromDate, LocalDate toDate) {
+        return employeeRepository.countByFilters(status, fromDate, toDate);
+    }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 대시보드 메인에서 총 직원 수 12명으로 고정됨
- 직원 수가 늘어나도 증감률이 바뀌지 않음

## 🔧 주요 작업 내용
- [x] 대시보드 메인에서 총 직원 수 12명으로 고정되던 부분 수정
- [x] 단위 기간을 바꿔도 월별로 고정되어 증감률이 바뀌지 않던 부분 수정
## ✅ 확인 사항

## 🧪 테스트 방법

![변경 전](https://github.com/user-attachments/assets/880af8b7-29c7-422e-bc2c-dbdd19a0e0d8)
(변경 전)
<img width="1457" alt="스크린샷 2025-06-12 오전 1 19 48" src="https://github.com/user-attachments/assets/fce65f42-bc6a-4ca3-bee1-6013883c13d3" />
<img width="1457" alt="스크린샷 2025-06-12 오전 1 19 40" src="https://github.com/user-attachments/assets/7a587bfc-4116-4149-a67a-f97c636fdb0c" />
<img width="1457" alt="변경 후" src="https://github.com/user-attachments/assets/99847da3-4c11-46a9-84c9-3d0a6abeacb2" />
(변경 후)


## 📎 기타 참고 사항

## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션을 준수했습니다. 
- [x] 변경 사항에 대한 테스트를 수행했습니다.